### PR TITLE
Introduce Dependabot for dependency updates and changelog changes.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+updates:
+  - package-ecosystem: "npm" # See documentation for possible values
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "daily"
+    assignees:
+      - "felix-hcl"
+    open-pull-requests-limit: 5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,10 @@
 ### Fixed
 
 ### Changed
+-'The "page-add" icon is deprecated and will be removed in future releases. Please use "page--add" instead.'
 
 #### Breaking changes
-
+-
 ## 1.3.0
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 -'The "page-add" icon is deprecated and will be removed in future releases. Please use "page--add" instead.'
 
 #### Breaking changes
--
+
 ## 1.3.0
 
 ### Added


### PR DESCRIPTION
-introducing Dependabot for dependency updates
-changelog unreleased changes for "page-add" icon is deprecating in future.