### PR TITLE
Add return icon to enchanted-icon repository

### DIFF
--- a/exclude_rename_icons.json
+++ b/exclude_rename_icons.json
@@ -230,7 +230,6 @@
     "reference-architecture",
     "repo--artifact",
     "repo--source-code",
-    "return",
     "rule--data-quality",
     "run--mirror",
     "screen-map--set",
@@ -269,13 +268,13 @@
     "zos--sysplex",
     "zos"
   ],
-   "renames": {
-     "ibm-cloud--dedicated-host": "cloud--dedicated-host",
-     "ibm-cloud--internet-services": "cloud--internet-services",
-     "ibm-cloud--security-compliance-center": "cloud--security-compliance-center",
-     "ibm-cloud--subnets": "cloud--subnets",
-     "ibm-security": "security--alt",
-     "ibm-security--services": "security-services--alt",
-     "ibm-watson--orders": "orders"
-   }
+  "renames": {
+    "ibm-cloud--dedicated-host": "cloud--dedicated-host",
+    "ibm-cloud--internet-services": "cloud--internet-services",
+    "ibm-cloud--security-compliance-center": "cloud--security-compliance-center",
+    "ibm-cloud--subnets": "cloud--subnets",
+    "ibm-security": "security--alt",
+    "ibm-security--services": "security-services--alt",
+    "ibm-watson--orders": "orders"
+  }
 }

--- a/src/carbon/es/return/index.tsx
+++ b/src/carbon/es/return/index.tsx
@@ -1,0 +1,20 @@
+/* ======================================================================== *
+  * Copyright 2024 HCL America Inc.                                          *
+  * Licensed under the Apache License, Version 2.0 (the "License");          *
+  * you may not use this file except in compliance with the License.         *
+  * You may obtain a copy of the License at                                  *
+  *                                                                          *
+  * http://www.apache.org/licenses/LICENSE-2.0                               *
+  *                                                                          *
+  * Unless required by applicable law or agreed to in writing, software      *
+  * distributed under the License is distributed on an "AS IS" BASIS,        *
+  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. *
+  * See the License for the specific language governing permissions and      *
+  * limitations under the License.                                           *
+  * ======================================================================== */
+
+/* auto generated file - do not edit */
+import Icon from '@carbon/icons/es/return/32';
+import { createSvgIcon } from '../../../utils';
+
+export default createSvgIcon(Icon.name, Icon.size, Icon.content, Icon.attrs);


### PR DESCRIPTION
As part of this ticket, we have added a icon "Return" to enchanted-icons library. below is the details of the issue. 
https://github.com/HCL-TECH-SOFTWARE/enchanted-icons/issues/34